### PR TITLE
Revert "Use style from the original node, not the clone"

### DIFF
--- a/src/get-clone-dimensions.js
+++ b/src/get-clone-dimensions.js
@@ -2,7 +2,7 @@ export default function getCloneDimensions(node, options) {
   const { parentNode } = node
   const context = document.createElement('div')
   const clone = node.cloneNode(true)
-  const style = getComputedStyle(node)
+  const style = getComputedStyle(clone)
   let rect = {}
 
   // give the node some context to measure off of


### PR DESCRIPTION
Reverts souporserious/get-node-dimensions#2
